### PR TITLE
Body is now parsed according to Content-Length

### DIFF
--- a/uHTTP.h
+++ b/uHTTP.h
@@ -33,6 +33,7 @@
 #define HEADER_TYPE     0
 #define HEADER_AUTH     1
 #define HEADER_ORIG     2
+#define HEADER_LENGTH   3
 
 // Sizes
 #define METHOD_SIZE     8
@@ -45,6 +46,7 @@ typedef struct Header{
   char type[HEAD_SIZE];
   char auth[HEAD_SIZE];
   char orig[HEAD_SIZE];
+  char length[HEAD_SIZE];
 };
 
 class uHTTP{


### PR DESCRIPTION
First of all thanks for that library that I've benn able to use into my own communication library named [WoopsaArduino](https://github.com/woopsa-protocol/WoopsaArduino).

I'd like to suggest you with those little modifications to improve the body parsing. Indeed, while using your library I've run into issues with client sending requests split into multiple TCP packets. Your actual code cannot deal with that because it stops the processing as soon as no more data is available from the client. Thus when request body is sent in another packet it is not treated. To fix that and to be more HTTP compliant, I've modified your code to take into account the `Content-Length` header and to stop only when everything is received.

However please note that 
* this is quite dirty code
* there is no timeout management for the case where content-length is wrong
* The STOP state could probably be used again by moving a bit of code around

Also, during my tests with _Wireshark_, i've noticed that content stored in flash using `F()` is sent **char by char** through the network. This is working for sure, but it may not be very good regarding performances. Don't know if it's a bug in the Arduino libraries or what.

Thanks again for you library and good continuation!